### PR TITLE
Track player stats and streaks

### DIFF
--- a/scenes/player_slot.tscn
+++ b/scenes/player_slot.tscn
@@ -33,3 +33,14 @@ grow_horizontal = 2
 grow_vertical = 2
 text = "Player 1"
 vertical_alignment = 1
+
+[node name="Stats" type="Label" parent="Background"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 120.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "W:0 L:0 WS:0 LS:0"
+vertical_alignment = 1

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -4,6 +4,7 @@ extends Node2D
 @onready var players: Node = $Players
 
 const PLAYER_SCENE = preload("res://scenes/player.tscn")
+var match_finished: bool = false
 
 func _ready() -> void:
 	NetworkManager.all_in_game.connect(_spawn_all)
@@ -29,11 +30,14 @@ func add_score(score: int, shooter_id: int) -> void:
 			player.add_score(score)
 
 func _on_player_died(player_id: int) -> void:
-	print(players.get_children())
-	var alive_players = []
-	for p in players.get_children():
-		if not p.dead:
-			alive_players.append(p)
-	if alive_players.size() == 1:
-		print("Only one player is alive: ", alive_players[0].name)
+        print(players.get_children())
+        var alive_players = []
+        for p in players.get_children():
+                if not p.dead:
+                        alive_players.append(p)
+       if alive_players.size() == 1 and not match_finished:
+               match_finished = true
+               var winner_id = alive_players[0].name.to_int()
+               print("Only one player is alive: ", alive_players[0].name)
+               NetworkManager.record_match_result(winner_id)
 	

--- a/scripts/lobby.gd
+++ b/scripts/lobby.gd
@@ -21,11 +21,20 @@ func _add_players_to_display():
 	for c in v_box_container.get_children():
 		c.queue_free()
 	# Add all Players to the Lobby Display
-	for peer_id in NetworkManager.players:
-		var player_slot = PLAYER_SLOT.instantiate()
-		v_box_container.add_child(player_slot)
-		var player_name_node = player_slot.get_node_or_null("Background/PlayerName")
-		player_name_node.text = NetworkManager.players[peer_id]['username']
+        for peer_id in NetworkManager.players:
+                var player_slot = PLAYER_SLOT.instantiate()
+                v_box_container.add_child(player_slot)
+                var player_name_node = player_slot.get_node_or_null("Background/PlayerName")
+               player_name_node.text = NetworkManager.players[peer_id]['username']
+               var stats_node = player_slot.get_node_or_null("Background/Stats")
+               if stats_node:
+                       var p = NetworkManager.players[peer_id]
+                       stats_node.text = "W:%d L:%d WS:%d LS:%d" % [
+                               p.get("wins", 0),
+                               p.get("losses", 0),
+                               p.get("win_streak", 0),
+                               p.get("loss_streak", 0),
+                       ]
 
 func _on_players_updated(players: Dictionary) -> void:
 	_add_players_to_display()


### PR DESCRIPTION
## Summary
- Track wins, losses, win streaks and loss streaks on the server
- Broadcast updated stats to all clients and show them in the lobby
- Detect match winner and update stats accordingly

## Testing
- ⚠️ `godot --headless --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3478c96083259c81c59a0be611dc